### PR TITLE
Update error handling

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 /build
+/lib

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 /build
+/lib

--- a/index.js
+++ b/index.js
@@ -1,1 +1,0 @@
-module.exports = require('./build')

--- a/package.json
+++ b/package.json
@@ -3,12 +3,14 @@
   "version": "0.0.2",
   "description":
     "A WebSockets solution for Spotify's Connect API made using socket.io.",
-  "main": "index.js",
+  "main": "lib",
+  "module": "lib/index.js",
   "author": "Lawrence Holmes",
   "license": "MIT",
   "scripts": {
     "lint": "eslint .",
-    "build": "yarn lint && babel -d ./build ./src"
+    "build": "yarn lint && babel -d ./lib ./src",
+    "watch": "babel -d ./lib ./src --watch"
   },
   "dependencies": {
     "node-fetch": "^1.7.3"

--- a/package.json
+++ b/package.json
@@ -1,8 +1,7 @@
 {
   "name": "spotify-connect-ws",
-  "version": "0.0.2",
-  "description":
-    "A WebSockets solution for Spotify's Connect API made using socket.io.",
+  "version": "0.1.0",
+  "description": "A WebSockets solution for Spotify's Connect API made using socket.io.",
   "main": "lib",
   "module": "lib/index.js",
   "author": "Lawrence Holmes",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "spotify-connect-ws",
   "version": "0.0.2",
-  "description": "A WebSockets solution for Spotify's Connect API made using socket.io.",
+  "description":
+    "A WebSockets solution for Spotify's Connect API made using socket.io.",
   "main": "index.js",
   "author": "Lawrence Holmes",
   "license": "MIT",
@@ -10,12 +11,12 @@
     "build": "yarn lint && babel -d ./build ./src"
   },
   "dependencies": {
-    "babel-core": "^6.26.0",
-    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "node-fetch": "^1.7.3"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
+    "babel-core": "^6.26.0",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.6.1",
     "eslint": "^4.10.0",
     "eslint-config-standard": "^10.2.1",

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,1 @@
-require('babel-core/register')
-
 module.exports = require('./socket')

--- a/src/socket.js
+++ b/src/socket.js
@@ -38,9 +38,7 @@ const spotifyConnectWs = socket => {
       )
     }
 
-    if (accessToken) {
-      socket.accessToken = accessToken
-    }
+    socket.accessToken = accessToken
 
     getPlayerState(socket.accessToken)
       .then(playerState => {
@@ -86,7 +84,7 @@ const spotifyConnectWs = socket => {
                 playerState.device.volume_percent !==
                 socket.playerState.device.volume_percent
               ) {
-                // device has changed
+                // volume has changed
                 socket.emit('volume_change', playerState.device.volume_percent)
               }
             }

--- a/src/spotify.js
+++ b/src/spotify.js
@@ -10,6 +10,12 @@ export const getPlayerState = accessToken => {
         'Content-Type': 'application/json'
       }
     })
+      .then(response => {
+        if (response.status === 202) {
+          return resolve({})
+        }
+        return response
+      })
       .then(r => r.json())
       .then(response => {
         if (response.error) {


### PR DESCRIPTION
This PR introduces a few improvements to the way that errors are handled.

- First of all, a check is now made to ensure that there is an active device before continuing on with the state comparisons. This fixes #1 (thanks @jfbausch).

- A reoccurring error will emit only one error event.

- Furthermore, a reoccurring error slows the poll rate (each reoccurrence increases poll time by 1 second, up to a maximum of 5 seconds).